### PR TITLE
Spelling corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ By default, the pages are constructed for a two-sided document (as if it were bi
 
 Chapters will always start on an odd page in the two-sided document, in accordance with the guidelines. In the one-sided document, chapters will open on any page. The title, approval, and dedication pages will display on an odd page regardless of the one-sided or two-sided settings.
 
-For initial drafts, the `draft` option removes some of the clutter in the front matter that is unnecessary before the published release. The removed front matter sections include the approval, dedication, acknowledgments pages as well as the preface which account for the sentimental and logistic portions of the document.
+For initial drafts, the `draft` option removes some of the clutter in the front matter that is unnecessary before the published release. The removed front matter sections include the approval, dedication, acknowledgements pages as well as the preface which account for the sentimental and logistic portions of the document.
 
 Finally, the `showframe` options should help debugging any layout problems.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ University*
 
 ## Implementation ##
 
-The mtu.thesis class is a direct extension to the report class; any features available for the report class are available to this thesis class. Additionally, this class provides a modified title page, as well as new commands and environments for an (optional) preface, approvals page, and dedication page as perscribed by the guidelines document for dissertations, theses, and reports at Michigan Tech. Formatting details have been applied to all the document
+The mtu.thesis class is a direct extension to the report class; any features available for the report class are available to this thesis class. Additionally, this class provides a modified title page, as well as new commands and environments for an (optional) preface, approvals page, and dedication page as prescribed by the guidelines document for dissertations, theses, and reports at Michigan Tech. Formatting details have been applied to all the document
 parts prescribed in the guidelines to ensure a uniform look-and-feel.
 
 ### Document Information ###
@@ -47,7 +47,7 @@ In document order, the following commands and environments are available for the
  3. `\begin{dedication} ... \end{dedication}` Make the dedication page (section 4.03), optionally. Content is limited to a single page.
  4. `\tableofcontents`, `\listoffigures`, `\listoftables` Make content lists (sections 4.04-06), as necessary.
  5. `\begin{preface} ... \end{preface}` Make the preface (section 4.07), when necessary. This environment is in a similar vein to the abstract environment.
- 6. `\begin{acknowledgements} ... \end{acknowledgements}` Make the acknowledgements (section 4.08), optionally. This environment is in a similar vein to the abstract environment
+ 6. `\begin{acknowledgments} ... \end{acknowledgments}` Make the acknowledgments (section 4.08), optionally. This environment is in a similar vein to the abstract environment
  7. `\begin{abstract} ... \end{abstract}` Make the abstract (section 4.11).
 
 Currently there is no support for a list of definitions (section 4.09) or a list of abbreviations (section 4.10). These can be added at a later point when a use-case arises.
@@ -58,14 +58,14 @@ By default, the pages are constructed for a two-sided document (as if it were bi
 
 Chapters will always start on an odd page in the two-sided document, in accordance with the guidelines. In the one-sided document, chapters will open on any page. The title, approval, and dedication pages will display on an odd page regardless of the one-sided or two-sided settings.
 
-For initial drafts, the `draft` option removes some of the clutter in the front matter that is unnecessary before the published release. The removed front matter sections include the approval, dedication, acknowledgements pages as well as the preface which account for the sentimental and logistic portions of the document.
+For initial drafts, the `draft` option removes some of the clutter in the front matter that is unnecessary before the published release. The removed front matter sections include the approval, dedication, acknowledgments pages as well as the preface which account for the sentimental and logistic portions of the document.
 
 Finally, the `showframe` options should help debugging any layout problems.
 
-The main matter, references, and appendixes use default report class constructs. There is no added material for these sections as they are well supported features of latex by default, although they have been styled appropriately to give a consistant look-and-feel.
+The main matter, references, and appendixes use default report class constructs. There is no added material for these sections as they are well supported features of latex by default, although they have been styled appropriately to give a consistent look-and-feel.
 
 ### Styling ###
 
-The document is styled around the concept of soft-capitals. The title and approval pages, along with headers, are styled with soft-caps and as such the dilligent user should consider using soft-caps for other structural formatting choices as well. This might include any header rows and or columns for tables, but probably shouldn't include minor points such as emphasis (`\emph`).
+The document is styled around the concept of soft-capitals. The title and approval pages, along with headers, are styled with soft-caps and as such the diligent user should consider using soft-caps for other structural formatting choices as well. This might include any header rows and or columns for tables, but probably shouldn't include minor points such as emphasis (`\emph`).
 
-The document is by default numbered with arabic numerals, unless the user provides the `\frontmatter` and `\mainmatter` commands to distingush the front matter from main matter. In that case, the front matter will be numbered with roman numerals and the main matter will be numbered with arabic numerals.
+The document is by default numbered with arabic numerals, unless the user provides the `\frontmatter` and `\mainmatter` commands to distinguish the front matter from main matter. In that case, the front matter will be numbered with roman numerals and the main matter will be numbered with arabic numerals.

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 The goal of this class is to represent the structure and formatting of
 dissertations, theses, and reports at Michigan Technological University, as
-required by the guidelines put forth by the Graduate School, in a terse, 
-unobtrusive, and idiomatic fashion. This is a no-nonsense approach geared towards people who are somewhat familiar with basic latex development or who are interested in learning. 
+required by the guidelines put forth by the Graduate School, in a terse,
+unobtrusive, and idiomatic fashion. This is a no-nonsense approach geared towards people who are somewhat familiar with basic latex development or who are interested in learning.
 
 *Please note: while I have taken strides to meet as many formatting guidelines
 as are reasonably possible to enforce in an idiomatic fashion, I make no
@@ -47,7 +47,7 @@ In document order, the following commands and environments are available for the
  3. `\begin{dedication} ... \end{dedication}` Make the dedication page (section 4.03), optionally. Content is limited to a single page.
  4. `\tableofcontents`, `\listoffigures`, `\listoftables` Make content lists (sections 4.04-06), as necessary.
  5. `\begin{preface} ... \end{preface}` Make the preface (section 4.07), when necessary. This environment is in a similar vein to the abstract environment.
- 6. `\begin{acknowledgments} ... \end{acknowledgments}` Make the acknowledgments (section 4.08), optionally. This environment is in a similar vein to the abstract environment
+ 6. `\begin{acknowledgements} ... \end{acknowledgements}` Make the acknowledgements (section 4.08), optionally. This environment is in a similar vein to the abstract environment
  7. `\begin{abstract} ... \end{abstract}` Make the abstract (section 4.11).
 
 Currently there is no support for a list of definitions (section 4.09) or a list of abbreviations (section 4.10). These can be added at a later point when a use-case arises.
@@ -69,3 +69,9 @@ The main matter, references, and appendixes use default report class constructs.
 The document is styled around the concept of soft-capitals. The title and approval pages, along with headers, are styled with soft-caps and as such the diligent user should consider using soft-caps for other structural formatting choices as well. This might include any header rows and or columns for tables, but probably shouldn't include minor points such as emphasis (`\emph`).
 
 The document is by default numbered with arabic numerals, unless the user provides the `\frontmatter` and `\mainmatter` commands to distinguish the front matter from main matter. In that case, the front matter will be numbered with roman numerals and the main matter will be numbered with arabic numerals.
+
+### Compatibility ###
+
+The following packages are known to cause compatibility issues:
+
+  - fullpage: ignores inner/outer margin settings defined by the package

--- a/mtu.thesis.cls
+++ b/mtu.thesis.cls
@@ -182,7 +182,7 @@
 \fi
 
 %%%
-%%% [4.08] acknowledgments
+%%% [4.08] acknowledgements
 \if@draft
 \excludecomment{acknowledgements}
 \excludecomment{acknowledgments}

--- a/mtu.thesis.cls
+++ b/mtu.thesis.cls
@@ -8,11 +8,11 @@
 % ensure that their dissertation, thesis, or report is in accordance with the
 % requirements specified by the graduate school.
 %
-% The class is presented as an extention of the default report class, and is
+% The class is presented as an extension of the default report class, and is
 % designed in as non-invasive of a method possible in order to maintain the
 % expectations and flexibility of that class.
 %
-% Wherever possible, citations to the afformentioned guide are provided as a
+% Wherever possible, citations to the aforementioned guide are provided as a
 % description for changes.
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesClass{mtu.thesis}[2015/09/22 Michigan Technological University Thesis]
@@ -178,12 +178,12 @@
 \fi
 
 %%%
-%%% [4.08] acknowledgements
+%%% [4.08] acknowledgments
 \if@draft
 \excludecomment{acknowledgements}
 \else
-\newenvironment{acknowledgements}
-{\chapter*{Acknowledgements}\addcontentsline{toc}{chapter}{Acknowlegments}}{}
+\newenvironment{acknowledgments}
+{\chapter*{Acknowledgments}\addcontentsline{toc}{chapter}{Acknowledgments}}{}
 \fi
 
 %%%

--- a/sample.tex
+++ b/sample.tex
@@ -84,13 +84,13 @@ Dissertation Advisor & My Advisor           \cr
 
 \lipsum[3]
 
-\note{Captions go below a figure and above a table. The classic argument for this use case is that tabular data is a textual device and follows the english reading convention of top-down, left to right reading whereas captions are iconic and are not instinctually scanned as text.}
+\note{Captions go below a figure and above a table. The classic argument for this use case is that tabular data is a textual device and follows the English reading convention of top-down, left to right reading whereas captions are iconic and are not  instinctually scanned as text.}
 
 \begin{figure}[t]
 \centering
 \includegraphics[width=.48\linewidth]{example-image-a}\hfill
 \includegraphics[width=.48\linewidth]{example-image-b}
-\caption[The \emph{mwe} pacakge is pretty great!]{Like the \emph{lipsum} pacakge for text, there is there \emph{mwe} pacakge for images. Enjoy these glorious images in your sample file!}
+\caption[The \emph{mwe} package is pretty great!]{Like the \emph{lipsum} package for text, there is there \emph{mwe} package for images. Enjoy these glorious images in your sample file!}
 \end{figure}
 
 \lipsum[4-6]


### PR DESCRIPTION
I left the spelling of acknowledgement(s) in the British style since having it spelled differently in the command and in the text seemed odd. I didn't want to change the command here for the sake of backwards compatibility. Other changes were consistent with American spelling. 